### PR TITLE
DDBTEAM-295: Fixed null error on auth in doctrine filter

### DIFF
--- a/src/Doctrine/CurrentUserExtension.php
+++ b/src/Doctrine/CurrentUserExtension.php
@@ -64,7 +64,7 @@ class CurrentUserExtension implements QueryCollectionExtensionInterface, QueryIt
         /** @var User $user */
         $user = $this->security->getUser();
 
-        if (in_array($resourceClass, [Material::class, Cover::class]) || null !== $user) {
+        if (in_array($resourceClass, [Material::class, Cover::class]) && null !== $user) {
             $rootAlias = $queryBuilder->getRootAliases()[0];
             $queryBuilder->andWhere(sprintf('%s.agencyId = :current_agency', $rootAlias));
             $queryBuilder->setParameter('current_agency', $user->getAgency());


### PR DESCRIPTION
Calling the endpoints reults in `Call to a member function getAgency() on null` because the doctrine filter gets called before auth is determined. So if api consumer is not authenticated the `$user->getAgency()` in the doctrine filter will fail.